### PR TITLE
Expand password hash column size

### DIFF
--- a/parking_app/models.py
+++ b/parking_app/models.py
@@ -89,7 +89,7 @@ class Credential(db.Model, Type2Mixin):
     Credential_ID = db.Column(db.Integer, primary_key=True)
     User_ID = db.Column(db.Integer, db.ForeignKey("Users.User_ID"), nullable=False)
     Username = db.Column(db.String(80), unique=True, nullable=False)
-    Password_Hash = db.Column(db.String(128), nullable=False)
+    Password_Hash = db.Column(db.String(255), nullable=False)
 
     def set_password(self, password: str) -> None:
         self.Password_Hash = generate_password_hash(password)


### PR DESCRIPTION
## Summary
- allow longer password hashes by increasing `Credential.Password_Hash` column to 255 characters
- verified schema and sign-up flow handle longer hashes after recreating the database

## Testing
- `python -m py_compile parking_app/models.py`
- Scripted sign-up of a security company via Flask test client and confirmed hash length 162


------
https://chatgpt.com/codex/tasks/task_e_689fb85ea8488330b787afc9375c5a56