### PR TITLE
Add security dashboard and collect additional signup info

### DIFF
--- a/parking_app/models.py
+++ b/parking_app/models.py
@@ -32,6 +32,7 @@ class PropertyCustomer(db.Model, Type2Mixin):
     Property_City = db.Column(db.String(100))
     Property_State = db.Column(db.String(2))
     Property_Zip = db.Column(db.String(10))
+    Contact_Number = db.Column(db.String(20))
 
     users = db.relationship("User", backref="property", lazy=True)
     parking_customers = db.relationship("ParkingCustomer", backref="property", lazy=True)
@@ -46,6 +47,7 @@ class SecurityCustomer(db.Model, Type2Mixin):
 
     Security_ID = db.Column(db.Integer, primary_key=True)
     Security_Name = db.Column(db.String(128), nullable=False)
+    Security_Address = db.Column(db.String(256))
     Security_City = db.Column(db.String(100))
     Security_State = db.Column(db.String(2))
     Security_Zip = db.Column(db.String(10))

--- a/parking_app/templates/security_dashboard.html
+++ b/parking_app/templates/security_dashboard.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Security Dashboard</h2>
+<h3>Properties</h3>
+<ul>
+  {% for prop in properties %}
+  <li>{{ prop.Property_Name }}</li>
+  {% else %}
+  <li>No properties assigned.</li>
+  {% endfor %}
+</ul>
+
+{% if current_user.Role == 'security_admin' %}
+<h3>Add Employee</h3>
+<form method="post">
+  <div class="mb-3">
+    <input class="form-control" name="first_name" placeholder="First Name" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="last_name" placeholder="Last Name" required>
+  </div>
+  <div class="mb-3">
+    <select class="form-select" name="role" required>
+      <option value="security_admin">Admin</option>
+      <option value="security_guard">Security Guard</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="username" placeholder="Username" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" type="password" name="password" placeholder="Password" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Add User</button>
+</form>
+
+<h3>Employees</h3>
+<ul>
+  {% for emp in employees %}
+  <li>{{ emp.First_Name }} {{ emp.Last_Name }} ({{ emp.Role }})
+    {% if emp.User_ID != current_user.User_ID %}
+    <form method="post" action="{{ url_for('main.remove_employee', user_id=emp.User_ID) }}" style="display:inline">
+      <button class="btn btn-sm btn-danger" type="submit">Remove</button>
+    </form>
+    {% endif %}
+  </li>
+  {% else %}
+  <li>No employees.</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/parking_app/templates/signup_property.html
+++ b/parking_app/templates/signup_property.html
@@ -6,6 +6,21 @@
     <input class="form-control" name="property_name" placeholder="Property Name" required>
   </div>
   <div class="mb-3">
+    <input class="form-control" name="property_address" placeholder="Address" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="property_city" placeholder="City" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="property_state" placeholder="State" maxlength="2" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="property_zip" placeholder="Zip" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="contact_number" placeholder="Contact Number" required>
+  </div>
+  <div class="mb-3">
     <input class="form-control" name="username" placeholder="Username" required>
   </div>
   <div class="mb-3">

--- a/parking_app/templates/signup_security.html
+++ b/parking_app/templates/signup_security.html
@@ -6,6 +6,18 @@
     <input class="form-control" name="security_name" placeholder="Company Name" required>
   </div>
   <div class="mb-3">
+    <input class="form-control" name="security_address" placeholder="Address" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="security_city" placeholder="City" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="security_state" placeholder="State" maxlength="2" required>
+  </div>
+  <div class="mb-3">
+    <input class="form-control" name="security_zip" placeholder="Zip" required>
+  </div>
+  <div class="mb-3">
     <input class="form-control" name="username" placeholder="Username" required>
   </div>
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- Extend property and security signup forms to capture address details and property contact number
- Introduce dashboard for security companies with property list and employee management
- Allow security admins to add or remove employees with admin or guard roles

## Testing
- `python -m py_compile parking_app/models.py parking_app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a21d26515c833080dc9a6d581880eb